### PR TITLE
Add errors to SecupayRuby::RequestError as object too

### DIFF
--- a/lib/secupay_ruby/exceptions.rb
+++ b/lib/secupay_ruby/exceptions.rb
@@ -1,4 +1,12 @@
 module SecupayRuby
-  class RequestError < StandardError; end
   class PaymentStatusError < StandardError; end
+
+  class RequestError < StandardError
+    attr_accessor :errors
+
+    def initialize(message_or_errors = nil)
+      self.errors = message_or_errors if message_or_errors.is_a?(Array)
+      super
+    end
+  end
 end

--- a/spec/request_error_spec.rb
+++ b/spec/request_error_spec.rb
@@ -1,24 +1,24 @@
 require "spec_helper"
 
 describe SecupayRuby::RequestError do
-  subject { described_class.new(errors) }
+  subject(:request_error) { described_class.new(errors) }
 
   let(:errors) { 'Request failed' }
 
-  it { expect(subject.message).to eql 'Request failed' }
-  it { expect(subject.errors).to be_nil }
+  it { expect(request_error.message).to eql 'Request failed' }
+  it { expect(request_error.errors).to be_nil }
 
   context 'with error object' do
     let(:errors) { [{ 'code' => '3', 'message' => 'Requested service is not available' }] }
 
-    it { expect(subject.message).to eql '[{"code"=>"3", "message"=>"Requested service is not available"}]' }
-    it { expect(subject.errors).to eql errors }
+    it { expect(request_error.message).to eql '[{"code"=>"3", "message"=>"Requested service is not available"}]' }
+    it { expect(request_error.errors).to eql errors }
   end
 
   context 'without' do
     let(:errors) { nil }
 
-    it { expect(subject.message).to eql 'SecupayRuby::RequestError' }
-    it { expect(subject.errors).to be_nil }
+    it { expect(request_error.message).to eql 'SecupayRuby::RequestError' }
+    it { expect(request_error.errors).to be_nil }
   end
 end

--- a/spec/request_error_spec.rb
+++ b/spec/request_error_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe SecupayRuby::RequestError do
+  subject { described_class.new(errors) }
+
+  let(:errors) { 'Request failed' }
+
+  it { expect(subject.message).to eql 'Request failed' }
+  it { expect(subject.errors).to be_nil }
+
+  context 'with error object' do
+    let(:errors) { [{ 'code' => '3', 'message' => 'Requested service is not available' }] }
+
+    it { expect(subject.message).to eql '[{"code"=>"3", "message"=>"Requested service is not available"}]' }
+    it { expect(subject.errors).to eql errors }
+  end
+
+  context 'without' do
+    let(:errors) { nil }
+
+    it { expect(subject.message).to eql 'SecupayRuby::RequestError' }
+    it { expect(subject.errors).to be_nil }
+  end
+end

--- a/spec/requests/base_spec.rb
+++ b/spec/requests/base_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe SecupayRuby::Requests::Base do
+  include_context "configuration"
+
+  subject(:request) { request_class.post api_key: SecupayRuby::ApiKey::MasterKey.new }
+
+  let(:request_class) do
+    Class.new(described_class) do
+      def path
+        @path ||= ["foo", "bar"].join("/")
+      end
+    end
+  end
+
+  context 'when request fails' do
+    it 'sets error message' do
+      expect { request }.to raise_error(SecupayRuby::RequestError) { |error|
+        expect(error.message).to eql '[{"code"=>"3", "message"=>"Requested service is not available"}]'
+      }
+    end
+
+    it 'includes errors as object' do
+      expect { request }.to raise_error(SecupayRuby::RequestError) { |error|
+        expect(error.errors).to eql [{'code' => '3', 'message' => 'Requested service is not available' }]
+      }
+    end
+  end
+end


### PR DESCRIPTION
Set errors as attribute on request error. Useful to process it when rescuing the error.